### PR TITLE
Upgrade map-age-cleaner dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '10'
-  - '8'
-  - '7.6'
+  - '16'
+  - '14'
+  - '12'
 after_script:
   - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - '10'
   - '8'
-  - '6'
+  - '7.6'
 after_script:
   - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ node_js:
   - '16'
   - '14'
   - '12'
+  - '10'
+  - '8'
 after_script:
   - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	},
 	"main": "dist/index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=8"
 	},
 	"scripts": {
 		"prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	},
 	"main": "dist/index.js",
 	"engines": {
-		"node": ">=7.6"
+		"node": ">=12"
 	},
 	"scripts": {
 		"prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	},
 	"main": "dist/index.js",
 	"engines": {
-		"node": ">=6"
+		"node": ">=7.6"
 	},
 	"scripts": {
 		"prepublishOnly": "npm run build",
@@ -35,7 +35,7 @@
 		"expiry"
 	],
 	"dependencies": {
-		"map-age-cleaner": "^0.1.0"
+		"map-age-cleaner": "^0.2.0"
 	},
 	"devDependencies": {
 		"@types/delay": "^2.0.1",


### PR DESCRIPTION
This PR upgrades map-age-cleaner to the latest version, primarily for https://github.com/SamVerschueren/map-age-cleaner/pull/7. It could seem negligible at first, since expiry-map starts to be recommended by the popular [p-memoize](https://www.npmjs.com/package/p-memoize), I think a lot people will consider using expiry-map and they could benefit from this change.

